### PR TITLE
Add function declaration for send()

### DIFF
--- a/examples/communications/LoRa/LoRaP2P/LoRaP2P_TX/LoRaP2P_TX.ino
+++ b/examples/communications/LoRa/LoRaP2P/LoRaP2P_TX/LoRaP2P_TX.ino
@@ -28,6 +28,7 @@
 // Function declarations
 void OnTxDone(void);
 void OnTxTimeout(void);
+void send();
 
 #ifdef NRF52_SERIES
 #define LED_BUILTIN 35


### PR DESCRIPTION
Adding the declaration will fix this build error in PlatformIO...

```text
src/main.cpp: In function 'void setup()':
src/main.cpp:91:2: error: 'send' was not declared in this scope
```

Thanks :-)