### PR TITLE
Add some lines to avoid minor compilation errors when using PlatformIO.

### DIFF
--- a/examples/common/sensors/RAK1903_Optical_OPT3001/RAK1903_Optical_OPT3001.ino
+++ b/examples/common/sensors/RAK1903_Optical_OPT3001/RAK1903_Optical_OPT3001.ino
@@ -10,6 +10,8 @@
 #include <Wire.h>
 #include <ClosedCube_OPT3001.h> // Click here to get the library: http://librarymanager/All#OPT3001
 
+// Forward declarations for functions
+void printError(String text, OPT3001_ErrorCode error);
 
 ClosedCube_OPT3001 g_opt3001;
 #define OPT3001_ADDRESS 0x44

--- a/examples/common/sensors/RAK1904_Accelerate_LIS3DH/RAK1904_Accelerate_LIS3DH.ino
+++ b/examples/common/sensors/RAK1904_Accelerate_LIS3DH/RAK1904_Accelerate_LIS3DH.ino
@@ -8,7 +8,7 @@
 **/
 
 
-
+#include <Arduino.h>
 #include "SparkFunLIS3DH.h" //http://librarymanager/All#SparkFun-LIS3DH
 #include <Wire.h>
 


### PR DESCRIPTION
Add a forward declaration in _examples/common/sensors/RAK1903_Optical_OPT3001/RAK1903_Optical_OPT3001.ino_ for `printError()` because it's used in `configureSensor()` before its definition.
```
src\main.cpp: In function 'void configureSensor()':
src\main.cpp:29:5: error: 'printError' was not declared in this scope
```

Add `#include <Arduino.h>` in _examples/common/sensors/RAK1904_Accelerate_LIS3DH/RAK1904_Accelerate_LIS3DH.ino_ to avoid messages like this:
```
src\main.cpp: In function 'void lis3dh_read_data()':
src\main.cpp:22:3: error: 'Serial' was not declared in this scope
```