### PR TITLE
Fix RAK4630 New Bootloader DFU Error

### DIFF
--- a/bootloader/RAK4630/new/Adafruit_nRF52_Bootloader_new/src/sdk_config.h
+++ b/bootloader/RAK4630/new/Adafruit_nRF52_Bootloader_new/src/sdk_config.h
@@ -66,7 +66,7 @@
 #define HCI_MEM_POOL_ENABLED               1
 #define HCI_TX_BUF_SIZE                    600 // not used
 #define HCI_RX_BUF_SIZE                    600
-#define HCI_RX_BUF_QUEUE_SIZE              8   // must be power of 2
+#define HCI_RX_BUF_QUEUE_SIZE              16   // must be power of 2
 
 //==========================================================
 // <e> UART_ENABLED - nrf_drv_uart - UART/UARTE peripheral driver


### PR DESCRIPTION
This PR fixes the error while doing OTA DFU with the RAK4630 new bootloader. The issue has been discussed before [here](https://github.com/adafruit/Adafruit_nRF52_Bootloader/issues/35), but I believe the incorrect actions were taken to resolve it.  The fix is in fact the suggested increase in the `HCI_RX_BUF_QUEUE_SIZE` noted by a user on the original issue thread. I confirmed this fix using nRF Connect's DFU utility on both an Android(Pixel 3a) and iOS(iPhone 12 Pro Max). If you are testing this fix, be sure to do a `make clean` in the bootloader repo before compiling as the changes to `sdk_config.h` are not caught by make. 

@beegee-tokyo 