### PR TITLE
Update RAK18001_Buzzer.ino

### DIFF
--- a/examples/RAK4630/sensors/RAK18001_Buzzer/RAK18001_Buzzer.ino
+++ b/examples/RAK4630/sensors/RAK18001_Buzzer/RAK18001_Buzzer.ino
@@ -1,4 +1,3 @@
-
 /**
    @file RAK18001_Buzzer.ino
    @author rakwireless.com
@@ -29,7 +28,7 @@
 #define NTCL4 175
 #define NTCL5 196
 #define NTCL6 221
-#define NTCL7 248  
+#define NTCL7 248
 
 #define NTCH1 525
 #define NTCH2 589
@@ -39,64 +38,64 @@
 #define NTCH6 882
 #define NTCH7 990
 
-
 #define WHOLE 1
 #define HALF 0.5
 #define QUARTER 0.25
-#define EIGHTH 0.25
-#define SIXTEENTH 0.625
+#define EIGHTH 0.125
+#define SIXTEENTH 0.0625
 
 
-int tune[]=                 //List the frequencies according to the spectrum
+int tune[] = //List the frequencies according to the spectrum
 {
-  NTC5,NTC5,NTC6,
-  NTCH1,NTC6,NTC5,NTC6,NTCH1,NTC6,NTC5,
-  NTC3,NTC3,NTC3,NTC5,
-  NTC6,NTC6,NTC5,NTCH3,NTCH3,NTCH2,NTCH1,
-  NTCH2,NTCH1,NTCH2,
-  NTCH3,NTCH3,NTCH2,NTCH3,NTCH2,NTCH1,NTCH2,NTCH1,NTC6,
+  NTC5, NTC5, NTC6,
+  NTCH1, NTC6, NTC5, NTC6, NTCH1, NTC6, NTC5,
+  NTC3, NTC3, NTC3, NTC5,
+  NTC6, NTC6, NTC5, NTCH3, NTCH3, NTCH2, NTCH1,
+  NTCH2, NTCH1, NTCH2,
+  NTCH3, NTCH3, NTCH2, NTCH3, NTCH2, NTCH1, NTCH2, NTCH1, NTC6,
 
-  NTCH2,NTCH2,NTCH2,NTCH1,NTC6,NTC5,
-  NTC6,NTC5,NTC5,NTCH1,NTC6,NTC5,NTC1,NTC3,
-  NTC2,NTC1,NTC2,
-  NTC3,NTC5,NTC5,NTC3,NTCH1,NTC7,
-  NTC6,NTC5,NTC6,NTCH1,NTCH2,NTCH3,
+  NTCH2, NTCH2, NTCH2, NTCH1, NTC6, NTC5,
+  NTC6, NTC5, NTC5, NTCH1, NTC6, NTC5, NTC1, NTC3,
+  NTC2, NTC1, NTC2,
+  NTC3, NTC5, NTC5, NTC3, NTCH1, NTC7,
+  NTC6, NTC5, NTC6, NTCH1, NTCH2, NTCH3,
 
-  NTCH3,NTCH2,NTCH1,NTC5,NTCH1,NTCH2,NTCH3,
+  NTCH3, NTCH2, NTCH1, NTC5, NTCH1, NTCH2, NTCH3,
 
-  NTCH2,NTC0,NTCH3,NTCH2,
-  NTCH1,NTC0,NTCH2,NTCH1,NTC6,NTC0,
+  NTCH2, NTC0, NTCH3, NTCH2,
+  NTCH1, NTC0, NTCH2, NTCH1, NTC6, NTC0,
 
-  NTCH2,NTC6,NTCH1,NTCH1,NTCH1,NTC6,NTC5,NTC3,
+  NTCH2, NTC6, NTCH1, NTCH1, NTCH1, NTC6, NTC5, NTC3,
   NTC5,
-  NTC5,NTC6,NTCH1,NTC7,NTC6,
-  NTCH3,NTCH3,NTCH3,NTCH3,NTCH2,NTCH2,NTCH1,
-  NTC6,NTCH3,NTCH2,NTCH1,NTCH2,NTCH1,NTC6,
+  NTC5, NTC6, NTCH1, NTC7, NTC6,
+  NTCH3, NTCH3, NTCH3, NTCH3, NTCH2, NTCH2, NTCH1,
+  NTC6, NTCH3, NTCH2, NTCH1, NTCH2, NTCH1, NTC6,
   NTCH1,
 };
-float durt[]=                   //List the beats according to the notation
+
+float durt[] = //List the beats according to the notation
 {
-0.5,0.25,0.25,
-1.5,0.5,0.5,0.25,0.25,0.5,0.5,
-1+1+1,0.5,0.25,0.25,
-1.5,0.5,0.5,0.5,0.25,0.25,0.5,
-1+1+1,0.5,0.5,
-0.5,0.5,0.5,0.25,0.25,0.5,0.25,0.25,0.5,
-0.5,0.5,0.5,0.25,0.25,1+1,
-0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5,
-1+1+1,0.5,0.5,
+  HALF, QUARTER, QUARTER,
+  WHOLE + HALF, HALF, HALF, QUARTER, QUARTER, HALF, HALF,
+  WHOLE + WHOLE + WHOLE, HALF, QUARTER, QUARTER,
+  WHOLE + HALF, HALF, HALF, HALF, QUARTER, QUARTER, HALF,
+  WHOLE + WHOLE + WHOLE, HALF, HALF,
+  HALF, HALF, HALF, QUARTER, QUARTER, HALF, QUARTER, QUARTER, HALF,
+  HALF, HALF, HALF, QUARTER, QUARTER, WHOLE + WHOLE,
+  HALF, HALF, HALF, HALF, HALF, HALF, HALF, HALF,
+  WHOLE + WHOLE + WHOLE, HALF, HALF,
 
 
-1.5,0.5,0.5,0.5,0.5,0.5,
-1.5,0.5,1,0.5,0.25,0.25,
-1.5,0.5,0.5,0.5,0.5,0.25,0.25,
-1+1+1,0.5,0.25,0.25,
-1,0.5,0.25,0.25,1,1,
-0.5,0.5,0.5,0.5,1,0.25,0.25,0.5,
-1+1+1+1,
-0.5,0.5,0.5,0.5,1+1,
-0.5,0.5,0.5,0.5,1.5,0.25,0.25,
-1.5,0.5,1,0.25,0.25,0.25,0.25,1+1+1+1,
+  WHOLE + HALF, HALF, HALF, HALF, HALF, HALF,
+  WHOLE + HALF, HALF, WHOLE, HALF, QUARTER, QUARTER,
+  WHOLE + HALF, HALF, HALF, HALF, HALF, QUARTER, QUARTER,
+  WHOLE + WHOLE + WHOLE, HALF, QUARTER, QUARTER,
+  WHOLE, HALF, QUARTER, QUARTER, WHOLE, WHOLE,
+  HALF, HALF, HALF, HALF, WHOLE, QUARTER, QUARTER, HALF,
+  WHOLE + WHOLE + WHOLE + WHOLE,
+  HALF, HALF, HALF, HALF, WHOLE + WHOLE,
+  HALF, HALF, HALF, HALF, WHOLE + HALF, QUARTER, QUARTER,
+  WHOLE + HALF, HALF, WHOLE, QUARTER, QUARTER, QUARTER, QUARTER, WHOLE + WHOLE + WHOLE + WHOLE,
 
 };
 
@@ -106,16 +105,16 @@ void setup()
 {
   Serial.begin(115200);
   while (!Serial) {};
-  pinMode(BUZZER_CONTROL,OUTPUT);
-  length=sizeof(tune)/sizeof(tune[0]);   //Calculation length
+  pinMode(BUZZER_CONTROL, OUTPUT);
+  length = sizeof(tune) / sizeof(tune[0]); //Calculation length
 }
 void loop()
 {
-  for(int x=0; x < length; x++)
+  for (int x = 0; x < length; x++)
   {
-    tone(BUZZER_CONTROL,tune[x]);
-    delay(500*durt[x]);   //Here it is used to adjust the delay according to the beat. The 500 index can be adjusted by myself. In this music, I find that 500 is more suitable.
+    tone(BUZZER_CONTROL, tune[x]);
+    delay(500 * durt[x]); //Here it is used to adjust the delay according to the beat. The 500 index can be adjusted by myself. In this music, I find that 500 is more suitable.
     noTone(BUZZER_CONTROL);
   }
   delay(2000);
-}
+} 


### PR DESCRIPTION
Fixed values for EIGHTH (0.125) and  SIXTEENTH (0.0625)

Replaced numerical values in `durt[]` with their `WHOLE`, `HALF` etc equivalents.