### PR TITLE
Set the default max MTU size within the DFU transport to 23

### DIFF
--- a/bootloader/RAK4630/Latest/WisCore_RAK4631_Bootloader/lib/sdk11/components/libraries/bootloader_dfu/dfu_transport_ble.c
+++ b/bootloader/RAK4630/Latest/WisCore_RAK4631_Bootloader/lib/sdk11/components/libraries/bootloader_dfu/dfu_transport_ble.c
@@ -37,7 +37,7 @@
 
 
 #define BLEGAP_EVENT_LENGTH             6
-#define BLEGATT_ATT_MTU_MAX             247
+#define BLEGATT_ATT_MTU_MAX             23
 enum { BLE_CONN_CFG_HIGH_BANDWIDTH = 1 };
 
 #define DFU_REV_MAJOR                        0x00                                                    /** DFU Major revision number to be exposed. */

--- a/bootloader/RAK4630/Latest/WisCore_RAK4631_Bootloader/src/main.c
+++ b/bootloader/RAK4630/Latest/WisCore_RAK4631_Bootloader/src/main.c
@@ -128,7 +128,7 @@ void usb_teardown(void);
 
 // These value must be the same with one in dfu_transport_ble.c
 #define BLEGAP_EVENT_LENGTH             6
-#define BLEGATT_ATT_MTU_MAX             247
+#define BLEGATT_ATT_MTU_MAX             23
 enum { BLE_CONN_CFG_HIGH_BANDWIDTH = 1 };
 
 //--------------------------------------------------------------------+


### PR DESCRIPTION
This is a copy of a fix that was applied to the Adafruit boot loader to resolve an issue with OTAs not working with latest Nordic-DFU-Library. See: https://github.com/adafruit/Adafruit_nRF52_Bootloader/pull/293 which was used to resolve https://github.com/adafruit/Adafruit_nRF52_Bootloader/issues/287 and https://github.com/adafruit/Adafruit_nRF52_Bootloader/issues/269 The RAK bootloader is dealing with the same issues, attempting to do a BLE OTA (with android) will result in it being stuck at 100% the only current work around to this is to use extremely outdated versions of Nordic nRF Connect/DFU which isn't ideal. 